### PR TITLE
Add support for ticket requests.

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -3057,6 +3057,24 @@ OPENSSL_EXPORT void SSL_CTX_enable_pq_experiment_signal(SSL_CTX *ctx);
 OPENSSL_EXPORT int SSL_pq_experiment_signal_seen(const SSL *ssl);
 
 
+// TLS ticket request extension.
+//
+// draft-ietf-tls-ticketrequests defines a new TLS extension ticket_request used
+// to communicate the amount of desired tickets clients wish to receive for a
+// connection.
+
+// SSL_CTX_set_ticket_request_count configures the count in |ctx|.
+OPENSSL_EXPORT void SSL_CTX_set_ticket_request_count(SSL_CTX *ctx, uint8_t count);
+
+// SSL_CTX_set_ticket_request_limit overrides the default limit of tickets (2)
+// for servers in |ctx|.
+OPENSSL_EXPORT void SSL_CTX_set_ticket_request_limit(SSL_CTX *ctx, uint8_t limit);
+
+// SSL_get_ticket_request_count fetches the number of tickets requested from a client
+// using |ssl|. This API has undefined behavior for clients.
+OPENSSL_EXPORT uint8_t SSL_get_ticket_request_count(const SSL *ssl);
+
+
 // QUIC transport parameters.
 //
 // draft-ietf-quic-tls defines a new TLS extension quic_transport_parameters

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -274,6 +274,9 @@ extern "C" {
 #define TLSEXT_cert_compression_zlib 1
 #define TLSEXT_cert_compression_brotli 2
 
+// From https://tools.ietf.org/html/draft-ietf-tls-ticketrequests-03#section-4
+#define TLSEXT_TYPE_ticket_request 54539
+
 #define TLSEXT_MAXLEN_host_name 255
 
 // PSK ciphersuites from 4279

--- a/ssl/internal.h
+++ b/ssl/internal.h
@@ -2291,6 +2291,17 @@ struct SSL3_STATE {
   // sending/echoing the post-quantum experiment signal.
   bool pq_experiment_signal_seen : 1;
 
+  // tls_ticket_request_seen is true if the peer sent a ticket request
+  // extension.
+  bool ticket_request_seen : 1;
+
+  // ticket_request_count carries the ticket request count if one was observed.
+  uint8_t ticket_request_count;
+
+  // ticket_request_signal indicates that the client explicitly requested
+  // some number of tickets.
+  bool ticket_request_signal : 1;
+
   // alert_dispatch is true there is an alert in |send_alert| to be sent.
   bool alert_dispatch : 1;
 
@@ -3226,6 +3237,18 @@ struct ssl_ctx_st {
   // (for clients) or echoed (for servers) to indicate participation in an
   // experiment of post-quantum key exchanges.
   bool pq_experiment_signal : 1;
+
+  // ticket_request_count indicates the number of tickets requested from
+  // a client.
+  uint8_t ticket_request_count;
+
+  // ticket_request_signal indicates that the client explicitly requested
+  // some number of tickets.
+  bool ticket_request_signal : 1;
+
+  // ticket_request_limit indicates the default number of tickets to vend
+  // to clients. By default, the value is 2.
+  uint8_t ticket_request_limit;
 
  private:
   ~ssl_ctx_st();

--- a/ssl/s3_lib.cc
+++ b/ssl/s3_lib.cc
@@ -181,6 +181,8 @@ SSL3_STATE::SSL3_STATE()
       tls13_downgrade(false),
       token_binding_negotiated(false),
       pq_experiment_signal_seen(false),
+      ticket_request_seen(false),
+      ticket_request_count(0),
       alert_dispatch(false) {}
 
 SSL3_STATE::~SSL3_STATE() {}

--- a/ssl/tls13_server.cc
+++ b/ssl/tls13_server.cc
@@ -128,13 +128,13 @@ static bool add_new_session_tickets(SSL_HANDSHAKE *hs, bool *out_sent_tickets) {
 
   // TLS 1.3 recommends single-use tickets, so issue multiple tickets in case
   // the client makes several connections before getting a renewal.
-  static const int kNumTickets = 2;
+  uint8_t ticket_count = SSL_get_ticket_request_count(ssl);
 
   // Rebase the session timestamp so that it is measured from ticket
   // issuance.
   ssl_session_rebase_time(ssl, hs->new_session.get());
 
-  for (int i = 0; i < kNumTickets; i++) {
+  for (int i = 0; i < ticket_count; i++) {
     UniquePtr<SSL_SESSION> session(
         SSL_SESSION_dup(hs->new_session.get(), SSL_SESSION_INCLUDE_NONAUTH));
     if (!session) {
@@ -152,7 +152,6 @@ static bool add_new_session_tickets(SSL_HANDSHAKE *hs, bool *out_sent_tickets) {
           ssl->quic_method != nullptr ? 0xffffffff : kMaxEarlyDataAccepted;
     }
 
-    static_assert(kNumTickets < 256, "Too many tickets");
     uint8_t nonce[] = {static_cast<uint8_t>(i)};
 
     ScopedCBB cbb;


### PR DESCRIPTION
This change adds APIs to configure the TLS ticket request extension
defined in [1]. Clients indicate their desired count and servers
indicate their desired limit. Upon negotiation, TLS 1.3 servers send
a N tickets, where N = min(client count, server limit).

[1] https://datatracker.ietf.org/doc/draft-ietf-tls-ticketrequests/